### PR TITLE
Allow illuminate/support to be 5.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": ">=5.6.4",
     "akayaman/flysystem-azure-adapter": "~1.0.0.3",
-    "illuminate/support": "5.3.* || 5.4.* || 5.5.*"
+    "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Seeing diff manually of storage facade

* https://raw.githubusercontent.com/illuminate/support/v5.6.39/Facades/Storage.php
* https://raw.githubusercontent.com/illuminate/support/v5.5.40/Facades/Storage.php

it contains only diff in the comment, assume it is safe to update
