### PR TITLE
Add support illuminate/support ~5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
     {
       "name": "NAKAYAMA Atsushi",
       "email": "anaka@yo.rim.or.jp"
-}
+    }
   ],
   "license": "MIT",
   "require": {
     "php": ">=5.6.4",
     "akayaman/flysystem-azure-adapter": "~1.0.0.3",
-    "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.*"
+    "illuminate/support": "~5.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This change will add support laravel 5.3 and up to below 6

Need to manually compare since the commit tree is different:
https://raw.githubusercontent.com/illuminate/support/v5.8.36/Facades/Storage.php
https://raw.githubusercontent.com/illuminate/support/v5.5.40/Facades/Storage.php

There is no intellisense error, but may not work as intended

## Suggestion
- Update minor version and or add beta tag